### PR TITLE
Remove parallel

### DIFF
--- a/src/regression/main.jl
+++ b/src/regression/main.jl
@@ -105,7 +105,7 @@ function build_forest(
         end
     end
 
-    println("Testing 1, 2, 3")
+    #println("Testing 1, 2, 3")
 
     # OLD parallel way of doing the above
     # forest = Distributed.@distributed (vcat) for i in 1:n_trees

--- a/src/regression/main.jl
+++ b/src/regression/main.jl
@@ -105,6 +105,8 @@ function build_forest(
         end
     end
 
+    println("Testing 1, 2, 3")
+
     # OLD parallel way of doing the above
     # forest = Distributed.@distributed (vcat) for i in 1:n_trees
     #     inds = rand(rngs, 1:t_samples, n_samples)

--- a/test/match_old_version.jl
+++ b/test/match_old_version.jl
@@ -1,4 +1,6 @@
-using DecisionTree
+using DecisionTree, Random, LinearAlgebra
+
+Random.seed!(352)
 
 n = 100
 p = 5
@@ -6,4 +8,10 @@ p = 5
 y = randn(n)
 X = randn(n, p)
 
+X_new = randn(2*n, p)
+
 model = build_forest(y, X, 2, 10)
+
+preds = apply_forest(model, X_new)
+
+norm(preds)

--- a/test/match_old_version.jl
+++ b/test/match_old_version.jl
@@ -1,0 +1,9 @@
+using DecisionTree
+
+n = 100
+p = 5
+
+y = randn(n)
+X = randn(n, p)
+
+model = build_forest(y, X, 2, 10)


### PR DESCRIPTION
For regression forests only, remove the @distributed macro to parallelize bagging.